### PR TITLE
auth : tables tenants/tenant_users et claim tenantId dans le JWT

### DIFF
--- a/backend/Gateway/AuthService/Controllers/AuthController.cs
+++ b/backend/Gateway/AuthService/Controllers/AuthController.cs
@@ -13,11 +13,13 @@ namespace AuthService.Controllers
     {
         private readonly AuthDbContext _context;
         private readonly TokenService _tokenService;
+        private readonly Guid _defaultTenantId;
 
-        public AuthController(AuthDbContext context, TokenService tokenService)
+        public AuthController(AuthDbContext context, TokenService tokenService, IConfiguration config)
         {
             _context = context;
             _tokenService = tokenService;
+            _defaultTenantId = Guid.Parse(config["Tenancy:DefaultTenantId"] ?? TenantDefaults.DefaultTenantId);
         }
 
         [HttpPost("register")]
@@ -32,6 +34,16 @@ namespace AuthService.Controllers
             _context.Users.Add(user);
             await _context.SaveChangesAsync();
 
+            // Chaque utilisateur est rattaché à un tenant (boutique) : le MVP
+            // n'expose que la boutique par défaut, le modèle en autorise plusieurs.
+            _context.TenantUsers.Add(new TenantUser
+            {
+                TenantId = _defaultTenantId,
+                UserId = user.Id,
+                Role = user.Role
+            });
+            await _context.SaveChangesAsync();
+
             return Ok("Utilisateur créé avec succès.");
         }
 
@@ -42,7 +54,12 @@ namespace AuthService.Controllers
             if (user is null || !BCrypt.Net.BCrypt.Verify(dto.Password, user.PasswordHash))
                 return Unauthorized("Identifiants invalides.");
 
-            var token = _tokenService.CreateToken(user);
+            // Le tenant courant est dérivé de l'appartenance de l'utilisateur,
+            // jamais choisi arbitrairement par le client (rapport §5.1).
+            var membership = await _context.TenantUsers.FirstOrDefaultAsync(tu => tu.UserId == user.Id);
+            var tenantId = membership?.TenantId ?? _defaultTenantId;
+
+            var token = _tokenService.CreateToken(user, tenantId);
             return Ok(new { token });
         }
 

--- a/backend/Gateway/AuthService/Data/AuthDbContext.cs
+++ b/backend/Gateway/AuthService/Data/AuthDbContext.cs
@@ -7,4 +7,18 @@ public class AuthDbContext : DbContext
     public AuthDbContext(DbContextOptions<AuthDbContext> options) : base(options) { }
 
     public DbSet<User> Users => Set<User>();
+    public DbSet<Tenant> Tenants => Set<Tenant>();
+    public DbSet<TenantUser> TenantUsers => Set<TenantUser>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Tenant>()
+            .HasIndex(t => t.Slug)
+            .IsUnique();
+
+        modelBuilder.Entity<TenantUser>()
+            .HasKey(tu => new { tu.TenantId, tu.UserId });
+    }
 }

--- a/backend/Gateway/AuthService/Migrations/20260712094016_AddTenants.Designer.cs
+++ b/backend/Gateway/AuthService/Migrations/20260712094016_AddTenants.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AuthService.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712094016_AddTenants")]
+    partial class AddTenants
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.7");

--- a/backend/Gateway/AuthService/Migrations/20260712094016_AddTenants.cs
+++ b/backend/Gateway/AuthService/Migrations/20260712094016_AddTenants.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenants : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tenant_users",
+                columns: table => new
+                {
+                    tenant_id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    user_id = table.Column<int>(type: "INTEGER", nullable: false),
+                    role = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tenant_users", x => new { x.tenant_id, x.user_id });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "tenants",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    name = table.Column<string>(type: "TEXT", nullable: false),
+                    slug = table.Column<string>(type: "TEXT", nullable: false),
+                    created_at = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tenants", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_tenants_slug",
+                table: "tenants",
+                column: "slug",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tenant_users");
+
+            migrationBuilder.DropTable(
+                name: "tenants");
+        }
+    }
+}

--- a/backend/Gateway/AuthService/Models/TenantModel.cs
+++ b/backend/Gateway/AuthService/Models/TenantModel.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AuthService.Models;
+
+// Tables structurantes du modèle multi-tenant (rapport §5.5) :
+// un tenant représente une boutique, tenant_users associe les utilisateurs
+// à leurs boutiques avec un rôle. Un utilisateur peut appartenir à plusieurs tenants.
+[Table("tenants")]
+public class Tenant
+{
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Column("name")]
+    public string Name { get; set; } = default!;
+
+    [Column("slug")]
+    public string Slug { get; set; } = default!;
+
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+// Tenant par défaut du MVP : la boutique « Business First ». L'identifiant est
+// partagé avec la Gateway et les services (configuration Tenancy:DefaultTenantId).
+public static class TenantDefaults
+{
+    public const string DefaultTenantId = "11111111-1111-1111-1111-111111111111";
+    public const string DefaultTenantName = "Business First";
+    public const string DefaultTenantSlug = "business-first";
+}
+
+[Table("tenant_users")]
+public class TenantUser
+{
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    [Column("user_id")]
+    public int UserId { get; set; }
+
+    [Column("role")]
+    public string Role { get; set; } = default!;
+}

--- a/backend/Gateway/AuthService/Program.cs
+++ b/backend/Gateway/AuthService/Program.cs
@@ -64,6 +64,43 @@ using (var scope = app.Services.CreateScope())
     {
         dbContext.Database.Migrate();
     }
+
+    SeedTenants(dbContext, app.Configuration);
 }
 
 app.Run();
+
+// Tenant par défaut (boutique « Business First ») + rattachement des utilisateurs
+// existants : tout utilisateur doit appartenir à un tenant (rapport §4.6/§5.5).
+static void SeedTenants(AuthDbContext db, IConfiguration config)
+{
+    var defaultTenantId = Guid.Parse(config["Tenancy:DefaultTenantId"] ?? AuthService.Models.TenantDefaults.DefaultTenantId);
+
+    if (!db.Tenants.Any(t => t.Id == defaultTenantId))
+    {
+        db.Tenants.Add(new AuthService.Models.Tenant
+        {
+            Id = defaultTenantId,
+            Name = AuthService.Models.TenantDefaults.DefaultTenantName,
+            Slug = AuthService.Models.TenantDefaults.DefaultTenantSlug
+        });
+        db.SaveChanges();
+    }
+
+    var usersWithoutTenant = db.Users
+        .Where(u => !db.TenantUsers.Any(tu => tu.UserId == u.Id))
+        .ToList();
+
+    foreach (var user in usersWithoutTenant)
+    {
+        db.TenantUsers.Add(new AuthService.Models.TenantUser
+        {
+            TenantId = defaultTenantId,
+            UserId = user.Id,
+            Role = user.Role
+        });
+    }
+
+    if (usersWithoutTenant.Count > 0)
+        db.SaveChanges();
+}

--- a/backend/Gateway/AuthService/Services/TokenService.cs
+++ b/backend/Gateway/AuthService/Services/TokenService.cs
@@ -15,13 +15,16 @@ public class TokenService
         _config = config;
     }
 
-    public string CreateToken(User user)
+    public string CreateToken(User user, Guid tenantId)
     {
+        // Le token porte l'identité ET le tenant courant (exigence 2 du cahier des charges) :
+        // la Gateway propage ensuite ce tenant aux services internes.
         var claims = new[]
         {
             new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
             new Claim(JwtRegisteredClaimNames.Email, user.Email),
-            new Claim(ClaimTypes.Role, user.Role)
+            new Claim(ClaimTypes.Role, user.Role),
+            new Claim("tenantId", tenantId.ToString())
         };
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));


### PR DESCRIPTION
## Quoi
- Tables `tenants` et `tenant_users` (modèle du rapport §5.5) avec migration EF : un tenant = une boutique, un utilisateur peut appartenir à plusieurs tenants avec un rôle
- Boutique par défaut « Business First » seedée au démarrage, utilisateurs existants rattachés automatiquement
- Le JWT contient le claim `tenantId` (exigence 2 du cahier des charges) : le tenant courant est dérivé de l'appartenance de l'utilisateur, jamais choisi par le client (§5.1)

## Vérifié
Build AuthService OK, migration `AddTenants` générée (SQLite dev) — le schéma PostgreSQL est créé depuis le modèle comme avant.

## Référence rapport
Exigence 2 (§2.5), §4.6 (stratégie multi-tenant), §5.5 (tables structurantes)