### PR TITLE
gateway : routes protégées, propagation du contexte JWT et journalisation corrélée

### DIFF
--- a/backend/Gateway/Gateway/Program.cs
+++ b/backend/Gateway/Gateway/Program.cs
@@ -1,11 +1,10 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
-
-Microsoft.IdentityModel.Logging.IdentityModelEventSource.ShowPII = true; // Debug (optionnel)
 
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.UseKestrel();
@@ -24,7 +23,7 @@ builder.Services.AddCors(options =>
     });
 });
 
-// Cl secrte EXACTEMENT comme dans Flask
+// Validation des tokens JWT émis par AuthService (rapport §5.2).
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
@@ -37,14 +36,6 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ValidIssuer = builder.Configuration["Jwt:Issuer"],
             ValidAudience = builder.Configuration["Jwt:Audience"],
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
-        };
-        options.Events = new JwtBearerEvents
-        {
-            OnAuthenticationFailed = context =>
-            {
-                Console.WriteLine("AUTH ERROR: " + context.Exception.ToString());
-                return Task.CompletedTask;
-            }
         };
     });
 
@@ -78,60 +69,104 @@ if (!app.Environment.IsDevelopment())
     app.UseHttpsRedirection();
 }
 
+// Journalisation des requêtes (rapport §5.2, §5.9) : chaque requête reçoit un
+// correlationId qui est propagé aux services et permet de suivre le flux complet.
+app.Use(async (context, next) =>
+{
+    var correlationId = Guid.TryParse(context.Request.Headers["X-Correlation-Id"], out var incoming)
+        ? incoming
+        : Guid.NewGuid();
+    context.Request.Headers["X-Correlation-Id"] = correlationId.ToString();
+    context.Response.Headers["X-Correlation-Id"] = correlationId.ToString();
+
+    var stopwatch = Stopwatch.StartNew();
+    try
+    {
+        await next();
+    }
+    finally
+    {
+        stopwatch.Stop();
+        app.Logger.LogInformation(
+            "{Method} {Path} => {StatusCode} en {ElapsedMs}ms (correlationId={CorrelationId}, tenantId={TenantId})",
+            context.Request.Method,
+            context.Request.Path,
+            context.Response.StatusCode,
+            stopwatch.ElapsedMilliseconds,
+            correlationId,
+            context.Request.Headers["X-Tenant-Id"].ToString());
+    }
+});
+
 app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
 
-var protectedRoutes = new List<(string path, string method, string policy)>
+// Règles d'autorisation par préfixe de route (rapport §4.8) : la Gateway n'est
+// pas l'unique barrière — les services et la RLS complètent la défense en
+// profondeur — mais elle bloque les accès non autorisés au plus tôt.
+// Les GET du catalogue produits restent publics (vitrine de la boutique).
+var protectedRoutes = new List<(string prefix, string[] methods, string policy)>
 {
-    ("/api/payments/Payment", "GET", "RequireAdmin"),
-    //("/api/payments/Payment", "POST", "RequireAdmin"),
-    //("/api/payments/Payment", "PATCH", "RequireAdmin"),
-    //("/api/orders/place", "POST", "Authenticated"),
-    //("/api/orders/cancel", "PATCH", "Authenticated"),
-    //("/api/users/delete", "DELETE", "RequireAdmin")
+    ("/api/orders",    new[] { "GET", "POST", "DELETE" }, "Authenticated"),
+    ("/api/orders",    new[] { "PUT", "PATCH" },          "RequireAdmin"),
+    ("/api/payments",  new[] { "GET", "POST", "PUT", "PATCH", "DELETE" }, "RequireAdmin"),
+    ("/api/products",  new[] { "POST", "PUT", "PATCH", "DELETE" },        "RequireAdmin"),
+    ("/api/inventory", new[] { "GET", "POST", "PUT", "PATCH", "DELETE" }, "RequireAdmin"),
+    ("/api/shipping",  new[] { "GET" },                                    "Authenticated"),
+    ("/api/shipping",  new[] { "POST", "PUT", "PATCH", "DELETE" },         "RequireAdmin"),
 };
 
+var defaultTenantId = app.Configuration["Tenancy:DefaultTenantId"] ?? "11111111-1111-1111-1111-111111111111";
 
 app.MapReverseProxy(proxyPipeline =>
 {
     proxyPipeline.Use(async (context, next) =>
     {
-        var requestPath = context.Request.Path.Value;
+        var requestPath = context.Request.Path.Value ?? "";
         var requestMethod = context.Request.Method.ToUpperInvariant();
 
         var match = protectedRoutes.FirstOrDefault(r =>
-            r.path.Equals(requestPath, StringComparison.OrdinalIgnoreCase) &&
-            r.method.Equals(requestMethod, StringComparison.OrdinalIgnoreCase)
-        );
+            requestPath.StartsWith(r.prefix, StringComparison.OrdinalIgnoreCase) &&
+            r.methods.Contains(requestMethod));
 
-        if (!string.IsNullOrEmpty(match.path))
+        if (!string.IsNullOrEmpty(match.prefix))
         {
             var authService = context.RequestServices.GetRequiredService<IAuthorizationService>();
             var result = await authService.AuthorizeAsync(context.User, null, match.policy);
 
             if (!result.Succeeded)
             {
-                context.Response.StatusCode = match.policy == "RequireAdmin" ? 403 : 401;
+                context.Response.StatusCode = context.User.Identity?.IsAuthenticated == true ? 403 : 401;
                 await context.Response.WriteAsync(
-                    match.policy == "RequireAdmin"
-                        ? "Access Denied: Admin only."
-                        : "Unauthorized: Authentication required."
-                );
+                    context.Response.StatusCode == 403
+                        ? "Access Denied: insufficient permissions."
+                        : "Unauthorized: Authentication required.");
                 return;
             }
         }
+
+        // Les headers de contexte interne ne sont jamais acceptés du client :
+        // ils sont dérivés exclusivement du JWT validé par la Gateway.
+        context.Request.Headers.Remove("X-User-Id");
+        context.Request.Headers.Remove("X-User-Role");
+        context.Request.Headers.Remove("X-Tenant-Id");
+
         var userId = context.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
                   ?? context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-
-        // Ajoute l'ID utilisateur � l'en-t�te
         if (!string.IsNullOrEmpty(userId))
-        {
             context.Request.Headers["X-User-Id"] = userId;
-            //Pour le recup dans les controller
-            //var userId = Request.Headers["X-User-Id"].ToString();
-        }
+
+        var role = context.User.FindFirst(ClaimTypes.Role)?.Value;
+        if (!string.IsNullOrEmpty(role))
+            context.Request.Headers["X-User-Role"] = role;
+
+        // Propagation du tenant aux services internes (rapport §4.8) : celui du
+        // JWT pour un utilisateur connecté, la boutique par défaut pour un
+        // visiteur anonyme (vitrine publique du MVP).
+        var tenantId = context.User.FindFirst("tenantId")?.Value;
+        context.Request.Headers["X-Tenant-Id"] = string.IsNullOrEmpty(tenantId) ? defaultTenantId : tenantId;
 
         await next();
     });

--- a/backend/Gateway/Gateway/appsettings.json
+++ b/backend/Gateway/Gateway/appsettings.json
@@ -14,6 +14,9 @@
   },
   "AllowedHosts": "*",
   "UseCodeBasedConfig": "true",
+  "Tenancy": {
+    "DefaultTenantId": "11111111-1111-1111-1111-111111111111"
+  },
   "ReverseProxy": {
     "Routes": {
       "orders": {


### PR DESCRIPTION
## Quoi
- **Routes protégées réactivées et généralisées** (elles étaient commentées) : commandes → utilisateur authentifié, écritures produits/inventaire/paiements → admin, GET catalogue public (vitrine)
- Headers internes `X-User-Id` / `X-User-Role` / `X-Tenant-Id` **dérivés du JWT validé**, strippés s'ils viennent du client ; visiteur anonyme = boutique par défaut (`Tenancy:DefaultTenantId`)
- Journalisation de chaque requête (méthode, chemin, statut, durée) avec `correlationId` propagé aux services (§5.9)
- Suppression du mode debug PII et du log console des erreurs d'authentification

## Impact
Avant cette PR, `GET /api/orders` renvoyait toutes les commandes de tous les utilisateurs sans authentification.

## Référence rapport
§4.8 (sécurité applicative), §5.2 (rôles de la Gateway), §5.9 (observabilité)